### PR TITLE
Update XSpec release and Saxon HE runtime.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM openjdk:8-jre
 MAINTAINER Sandro Cirulli <sandro@sandrocirulli.net>
 
 ENV XSPEC_VERSION=2.2.4
-ENV SAXON_VERSION=11.3
+ENV SAXON_VERSION=10.8
+ENV XML_RESOLVER_VERSION=4.3.0
 
 # install XSpec
 ENV XSPEC_DOWNLOAD_SHA256 8e473a4e889f553936071b28ad583ef477fe5fa711565af99cf48fdc726bc002
@@ -16,14 +17,13 @@ ENV XSPEC_HOME /xspec
 
 WORKDIR /xspec
 	
-# install Saxon HE
-ENV SAXON_DOWNLOAD_SHA256 e62e1a283b1aa610605fde18e9368a9ec6f24d878320eb74cfc1c1f2d432e8a6
+# install Saxon HE and dependencies
+ENV SAXON_DOWNLOAD_SHA256 f63e8fc48b5d00ab237aaca5f794a7a1efd7318380c36fadf9584e86bac4aa9d
+ENV SAXON_CP /xspec/saxon/* 
 RUN mkdir -p saxon && \
-	export SAXON_CP=/xspec/saxon/saxon11he.jar && \
-	curl -fSL -o ${SAXON_CP} https://repo.maven.apache.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar && \
-	echo ${SAXON_DOWNLOAD_SHA256} ${SAXON_CP} | sha256sum -c - && \
-	chmod +x ${SAXON_CP}
-ENV SAXON_CP /xspec/saxon/saxon11he.jar 
+	cd saxon && \
+	curl -fSL -o Saxon-HE-${SAXON_VERSION}.jar https://dev.saxonica.com/maven/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar && \
+	echo ${SAXON_DOWNLOAD_SHA256} Saxon-HE-${SAXON_VERSION}.jar | sha256sum -c -
 
 # use non-privileged user to run xspec
 RUN groupadd -r xspec && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM openjdk:8-jre
 
 MAINTAINER Sandro Cirulli <sandro@sandrocirulli.net>
 
-ENV XSPEC_VERSION=0.5.0
-ENV SAXON_VERSION=9.7.0-18
+ENV XSPEC_VERSION=2.2.4
+ENV SAXON_VERSION=11.3
 
 # install XSpec
-ENV XSPEC_DOWNLOAD_SHA256 d568a8b1dbc83dffb96fea477f75863a099a25a3e68c5792aa61a7cf9bfe7d6d
+ENV XSPEC_DOWNLOAD_SHA256 8e473a4e889f553936071b28ad583ef477fe5fa711565af99cf48fdc726bc002
 RUN curl -fSL -o xspec-${XSPEC_VERSION}.tar.gz https://github.com/xspec/xspec/archive/v${XSPEC_VERSION}.tar.gz && \
 	echo ${XSPEC_DOWNLOAD_SHA256} xspec-${XSPEC_VERSION}.tar.gz | sha256sum -c - && \
 	tar xvzf xspec-${XSPEC_VERSION}.tar.gz && \
@@ -17,13 +17,13 @@ ENV XSPEC_HOME /xspec
 WORKDIR /xspec
 	
 # install Saxon HE
-ENV SAXON_DOWNLOAD_SHA256 b8884cff013f4169fba13751a876794952858e9003e0726d4f9cb28d8bb09448
+ENV SAXON_DOWNLOAD_SHA256 e62e1a283b1aa610605fde18e9368a9ec6f24d878320eb74cfc1c1f2d432e8a6
 RUN mkdir -p saxon && \
-	export SAXON_CP=/xspec/saxon/saxon9he.jar && \
-	curl -fSL -o ${SAXON_CP} http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar && \
+	export SAXON_CP=/xspec/saxon/saxon11he.jar && \
+	curl -fSL -o ${SAXON_CP} https://repo.maven.apache.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar && \
 	echo ${SAXON_DOWNLOAD_SHA256} ${SAXON_CP} | sha256sum -c - && \
 	chmod +x ${SAXON_CP}
-ENV SAXON_CP /xspec/saxon/saxon9he.jar 
+ENV SAXON_CP /xspec/saxon/saxon11he.jar 
 
 # use non-privileged user to run xspec
 RUN groupadd -r xspec && \


### PR DESCRIPTION
- Update the release from xspec 0.5.x to 2.2.4, current stable.
- Update Saxon HE from 9.x to current 11.x release.
- Update Maven download location for Saxon HE as central.maven.org is
obsolete and we must pick another stable mirror for Saxon HE download.

Closes xspec/docker#1.